### PR TITLE
Update downloader.sh to handle new download links

### DIFF
--- a/linux_mac/downloader.sh
+++ b/linux_mac/downloader.sh
@@ -37,6 +37,8 @@ fi
 downloadUrl=$1
 outputDir=$2
 
+siteUrl="$(echo $downloadUrl | sed 's/\(https:\/\/[^\/]*\)\/.*$/\1/')"
+
 i=1
 
 	while :
@@ -54,7 +56,7 @@ i=1
 	while [ "$i" -le "$recentIssue" ]
 	do
     printf -v page_url $downloadUrl "$i"
-		pdf_url=`curl -sf $page_url | grep "c-link\" download=" | sed 's/^.*href=\"//' | sed 's/\?.*$//'`
+		pdf_url=`curl -sf $page_url | grep "c-link\"" | sed 's/^.*href=\"//' | sed 's/\(\?.*\)\?">.*$//' | sed "s#^\(/.*\)#$siteUrl\1#"`
 		wget -N $pdf_url -P $outputDir
 		i=$(( i+1 ))
 	done


### PR DESCRIPTION
Line in HTML for download link to MagPi, HackSpace, and Wireframe magazines has changed from

<a class="c-link" download="localfilename.pdf" href="https://site/link/remotefilename.pdf?code">click here to get your free PDF</a>.

to

<a class="c-link" href="/downloads/longstring/remotefilename.pdf">click here to get your free PDF</a>.

so have changed 3rd sed command for pdf_url to handle download="localfilename.pdf" if present (still used for Hello World) and added a 4th sed to prefix site URL if download link starts with forward slash (so shouldn't break Hello World download).